### PR TITLE
Add functionality for translations

### DIFF
--- a/.mocharc.json
+++ b/.mocharc.json
@@ -1,0 +1,6 @@
+{
+    "extension": ["js", "ts"],
+    "spec": "test/**/*",
+    "require": ["chai/register-expect.js", "ts-node/register"]
+  }
+  

--- a/nyc.config.js
+++ b/nyc.config.js
@@ -9,8 +9,8 @@ module.exports = {
   ],
   exclude: [
     'src/__tests__',
-    'src/index.ts',
     'src/types.ts',
+    'src/generated'
   ],
   statements: 80,
   branches: 80,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@xplora-uk/poeditor-client",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@xplora-uk/poeditor-client",
-      "version": "1.0.1",
+      "version": "1.1.0",
       "license": "MIT",
       "dependencies": {
         "@xplora-uk/axios-with-agentkeepalive": "^1.0.1",
@@ -19,6 +19,7 @@
         "@types/mocha": "^10.0.1",
         "@types/node": "^20.12.2",
         "chai": "^4.3.7",
+        "dotenv": "^16.4.5",
         "mocha": "^10.2.0",
         "npm-run-all": "^4.1.5",
         "nyc": "^15.1.0",
@@ -1782,6 +1783,18 @@
       "dev": true,
       "engines": {
         "node": ">=0.3.1"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "16.4.5",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.5.tgz",
+      "integrity": "sha512-ZmdL2rui+eB2YwhsWzjInR8LldtZHGDoQ1ugH85ppHKwpUHL7j7rN0Ti9NCnGiQbhaZ11FpR+7ao1dNsmduNUg==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
       }
     },
     "node_modules/easy-table": {

--- a/package.json
+++ b/package.json
@@ -1,9 +1,10 @@
 {
   "name": "@xplora-uk/poeditor-client",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Unofficial node client for PO Editor API",
   "main": "lib/index.js",
   "type": "commonjs",
+  "module": "commonjs",
   "types": "lib/index.d.ts",
   "files": [
     "lib"
@@ -16,8 +17,8 @@
     "openapi:tidy": "rimraf ./src/generated/.openapi-generator ./src/generated/.openapi-generator-ignore ./src/generated/git_push.sh ./src/generated/.gitignore ./src/generated/.npmignore",
     "openapi:gen": "openapi-generator-cli generate -i poeditor.yaml -g typescript-axios -o ./src/generated",
     "openapi": "npm-run-all openapi:clean openapi:gen openapi:tidy",
-    "test": "mocha ./src/__tests__/**/*.test.ts",
-    "test:component": "mocha ./src/__tests__/component/**/*.test.ts",
+    "test": "mocha ./src/__tests__/**/*.test.ts -r dotenv/config",
+    "test:component": "mocha ./src/__tests__/component/**/*.test.ts -r dotenv/config",
     "test:coverage": "nyc npm run test"
   },
   "repository": {
@@ -46,6 +47,7 @@
     "@types/mocha": "^10.0.1",
     "@types/node": "^20.12.2",
     "chai": "^4.3.7",
+    "dotenv": "^16.4.5",
     "mocha": "^10.2.0",
     "npm-run-all": "^4.1.5",
     "nyc": "^15.1.0",

--- a/src/__tests__/component/index.test.ts
+++ b/src/__tests__/component/index.test.ts
@@ -1,9 +1,22 @@
 import { expect } from 'chai';
-import { PoEditorApi } from '../..';
+import { PoEditorApi, makeTermAndContext } from '../..';
+
+const API_TOKEN = process.env.API_TOKEN || '';
+const PROJECT_ID = process.env.PROJECT_ID || '';
 
 describe('PoEditorApi', () => {
   it('should be constructed', () => {
-    const api = new PoEditorApi('token', '12345');
+    const api = new PoEditorApi(API_TOKEN, PROJECT_ID);
     expect(api).to.be.an.instanceOf(PoEditorApi);
   });
 });
+
+describe('Make term and context', () => {
+  it('should return term and context', () => {
+   const sampleKey = '"Adventure"."adv-123"."title"';
+   const { term, context } = makeTermAndContext(sampleKey);
+    expect(term).to.be.equal('title');
+    expect(context).to.be.equal('"Adventure"."adv-123"');
+  });
+});
+

--- a/src/__tests__/component/terms.test.ts
+++ b/src/__tests__/component/terms.test.ts
@@ -1,0 +1,56 @@
+import { expect } from 'chai';
+import { PoEditorApi } from '../..';
+
+const API_TOKEN = process.env.API_TOKEN || '';
+const PROJECT_ID = process.env.PROJECT_ID || '';
+
+describe('poEditor terms', () => {
+  const api = new PoEditorApi(API_TOKEN, PROJECT_ID);
+  const defaultLanguage = 'en-gb';
+  const term1 = 'test';
+  const term2 = 'test2';
+  const termsPair1 = [`test.${term1}`, `test.${term2}`];
+  const termsPair2 = ['test.test3', 'test.test4'];
+
+  it('should add terms', async () => {  
+    const response = await api.addTerms(termsPair1);
+    
+    expect(response.result).to.ownProperty('terms');
+    const { parsed, added } = response.result!.terms!;
+    expect(parsed).to.be.equal(termsPair1.length);
+    expect(added).to.be.equal(termsPair1.length);
+  });
+
+  it('should list terms and check added ones', async () => {
+    const response = await api.listTerms(defaultLanguage);
+
+    expect(response.result).to.ownProperty('terms');
+    const { terms } = response.result!;
+    expect(terms).to.be.an('array');
+    expect(terms!.map(e => e.term)).to.include(term1);
+    expect(terms!.map(e => e.term)).to.include(term2);
+  });
+
+  it('should update terms', async () => {
+    const response = await api.updateTerms([
+      { key: termsPair1[0], new_key: termsPair2[0] },
+      { key: termsPair1[1], new_key: termsPair2[1] },
+    ]);
+    
+    expect(response.result).to.ownProperty('terms');
+    const { parsed, updated } = response.result!.terms!;
+    expect(parsed).to.be.equal(termsPair1.length);
+    expect(updated).to.be.equal(termsPair2.length);
+  });
+
+  it('should delete terms', async () => {
+    const response = await api.deleteTerms(termsPair2);
+    
+    expect(response.result).to.ownProperty('terms');
+    const { parsed, deleted } = response.result!.terms!;
+    expect(parsed).to.be.equal(termsPair2.length);
+    expect(deleted).to.be.equal(termsPair2.length);
+  });
+
+});
+

--- a/src/__tests__/component/translations.test.ts
+++ b/src/__tests__/component/translations.test.ts
@@ -1,0 +1,78 @@
+import { expect } from 'chai';
+import { PoEditorApi } from '../..';
+
+const API_TOKEN = process.env.API_TOKEN || '';
+const PROJECT_ID = process.env.PROJECT_ID || '';
+
+describe('poEditor translations', () => {
+  const api = new PoEditorApi(API_TOKEN, PROJECT_ID);
+  const defaultLanguage = 'en-gb';
+  const translations = {
+    'test.test': 'Translation test',
+    'test.test2': 'Translation test2'
+  }
+  const updatedTranslations = {
+    'test.test': 'Updated translation test',
+    'test.test2': 'Updated translation test2'
+  }
+
+  it('should add test terms', async () => {  
+    const response = await api.addTerms(Object.keys(translations));
+    
+    expect(response.result).to.ownProperty('terms');
+    const { parsed, added } = response.result!.terms!;
+    expect(parsed).to.be.equal(Object.keys(translations).length);
+    expect(added).to.be.equal(Object.keys(translations).length);
+  });
+
+  it('should add translations to the terms', async () => {
+    const languageObject = {
+      language: defaultLanguage,
+      translations: translations
+    }
+    const response = await api.addTranslations(languageObject.language, languageObject.translations);
+
+    expect(response).to.ownProperty('result');
+    const {result} = response;
+    expect(result).to.ownProperty('translations');
+    const { parsed, added } = result!.translations!;
+    expect(parsed).to.be.equal(Object.keys(translations).length);
+    expect(added).to.be.equal(Object.keys(translations).length);
+  });
+
+  it('should update translations to the terms', async () => {
+    const languageObject = {
+      language: defaultLanguage,
+      translations: updatedTranslations
+    };
+
+    const response = await api.updateTranslations(languageObject.language, languageObject.translations);
+    
+    expect(response).to.ownProperty('result');
+    const {result} = response;
+    expect(result).to.ownProperty('translations');
+    const { parsed, updated } = result!.translations!;
+    expect(parsed).to.be.equal(Object.keys(updatedTranslations).length);
+    expect(updated).to.be.equal(Object.keys(updatedTranslations).length);
+  });
+
+  it('should delete translations', async () => {
+    const response = await api.deleteTranslations(defaultLanguage, Object.keys(updatedTranslations));
+    
+    expect(response.result).to.ownProperty('translations');
+    const { parsed, deleted } = response.result!.translations!;
+    expect(parsed).to.be.equal(Object.keys(updatedTranslations).length);
+    expect(deleted).to.be.equal(Object.keys(updatedTranslations).length);
+  });
+
+  it('should delete terms', async () => {
+    const response = await api.deleteTerms(Object.keys(updatedTranslations));
+    
+    expect(response.result).to.ownProperty('terms');
+    const { parsed, deleted } = response.result!.terms!;
+    expect(parsed).to.be.equal(Object.keys(updatedTranslations).length);
+    expect(deleted).to.be.equal(Object.keys(updatedTranslations).length);
+  });
+
+});
+

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 import { createAxiosInstance } from '@xplora-uk/axios-with-agentkeepalive';
 import { AxiosInstance } from 'axios';
 import { URLSearchParams } from 'url';
-import { TermAddedResponse, TermDeletedResponse, TermUpdatedResponse, TermsListFullResponse } from './generated';
+import { TermAddedResponse, TermDeletedResponse, TermUpdatedResponse, TermsListFullResponse, TranslationAddedResponse, TranslationDeletedResponse, TranslationUpdatedResponse } from './generated';
 import { DataToAddTerms, DataToDeleteTerms, DataToUpdateTerms, InputToUpdateTerms } from './types';
 
 export class PoEditorApi {
@@ -18,7 +18,6 @@ export class PoEditorApi {
     readonly id: string,
     readonly baseURL = 'https://api.poeditor.com/v2',
   ) {
-    console.info('PoEditorApi constructor');
     this._client = createAxiosInstance({
       baseURL,
     });
@@ -65,6 +64,44 @@ export class PoEditorApi {
     return response.data;
   }
 
+  addTranslations = async (language: string, translations: Record<string, string>) => {
+    const translationsData: any[] = [];
+    Object.entries(translations).forEach(([key, translation]) => {
+      const { term, context } = makeTermAndContext(key);
+      translationsData.push({ term, context, translation: { content: translation } });
+    });
+    
+    const formData = this._makeFormData(translationsData);
+    formData.append('language', language);
+    const response = await this._client.post<TranslationAddedResponse>('/translations/add', formData.toString());
+    return response.data;
+  }
+  
+  updateTranslations = async (language: string, translations: Record<string, string>) => {
+    const translationsData: any[] = [];
+    Object.entries(translations).forEach(([key, translation]) => {
+      const { term, context } = makeTermAndContext(key);
+      translationsData.push({ term, context, translation: { content: translation } });
+    });
+    
+    const formData = this._makeFormData(translationsData);
+    formData.append('language', language);
+    const response = await this._client.post<TranslationUpdatedResponse>('/translations/update', formData.toString());
+    return response.data;
+  }
+
+  deleteTranslations = async (language: string, keys: string[]) => {
+    const translationsData: any[] = [];
+    keys.forEach(key => {
+      const { term, context } = makeTermAndContext(key);
+      translationsData.push({ term, context });
+    });
+    
+    const formData = this._makeFormData(translationsData);
+    formData.append('language', language);
+    const response = await this._client.post<TranslationDeletedResponse>('/translations/delete', formData.toString());
+    return response.data;
+  }
 }
 
 export function makeTermAndContext(key: string) {


### PR DESCRIPTION
add .mocharc.json to enable tests
update nyc.config.js to configure and get correct coverage reports included .env library to allow token configurations from env params added the following new functions
- addTranslations
- updateTranslations
- deleteTranslations added more tests for terms and translation